### PR TITLE
Fix Netlify plugin package syntax

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [[plugins]]
-  package = "@netlify/plugin-tanstack-start@latest"
+  package = "@netlify/plugin-tanstack-start"


### PR DESCRIPTION
### Motivation
- Netlify failed to parse `netlify.toml` because `plugins[].package` contained a version suffix (`@latest`), and Netlify requires a plain npm package name only.

### Description
- Updated `netlify.toml` to remove the `@latest` suffix so the plugin package is `@netlify/plugin-tanstack-start`.

### Testing
- Validated the change by inspecting the file with `sed -n '1,50p' netlify.toml` and `nl -ba netlify.toml`, which show the `package` line no longer contains the version suffix and match the expected syntax.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4b83d8048331b93b7567e780c003)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment plugin configuration to use alternative version resolution mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->