### PR TITLE
Configure Netlify TanStack Start Vite integration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
-[[plugins]]
-  package = "@netlify/plugin-tanstack-start"
+# Netlify configuration is managed in the Netlify UI.
+# The TanStack Start integration now uses the Vite plugin in vite.config.ts.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^1.1.1",
+    "@netlify/vite-plugin-tanstack-start": "^1.0.0",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/eslint-config": "^0.4.0",
     "@types/node": "^25.0.9",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import netlify from '@netlify/vite-plugin-tanstack-start'
 import { defineConfig } from 'vite'
 import tsConfigPaths from 'vite-tsconfig-paths'
 import tailwindcss from '@tailwindcss/vite'
@@ -14,6 +15,7 @@ export default defineConfig({
       projects: ['./tsconfig.json'],
     }),
     tanstackStart(),
+    netlify(),
     viteReact(),
   ],
 })


### PR DESCRIPTION
### Motivation
- Fix Netlify build error that required the TanStack Start integration to be available as a Vite plugin instead of a Netlify build plugin by installing the integration into the project and registering it in Vite.

### Description
- Added `@netlify/vite-plugin-tanstack-start` to `devDependencies` in `package.json` so the integration can be installed via npm.
- Updated `vite.config.ts` to import the Netlify Vite plugin and register `netlify()` alongside `tanstackStart()` in the `plugins` array.
- Replaced the legacy plugin entry in `netlify.toml` with a short note that Netlify configuration is managed in the UI and that the TanStack Start integration now lives in `vite.config.ts`.

### Testing
- Ran `npm install -D @netlify/vite-plugin-tanstack-start` and `npm install -D @netlify/plugin-tanstack-start`, both of which failed with `403 Forbidden` due to npm registry access restrictions in this environment.
- Ran `npm run build`, which failed with a missing module error (`Cannot find package '@netlify/vite-plugin-tanstack-start'`) because the plugin package could not be installed; this confirms the local build requires the package to be available from the registry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa531afe50833190dcaace889ca423)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Netlify deployment integration to use the TanStack Start Vite plugin, consolidating configuration management through the build tool and deployment platform for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->